### PR TITLE
Fix for "TypeError" issue with some precompiled contracts

### DIFF
--- a/src/tasks/size_contracts.ts
+++ b/src/tasks/size_contracts.ts
@@ -78,14 +78,14 @@ task('size-contracts', 'Output the size of compiled contracts')
 
         const { deployedBytecode, bytecode } =
           await hre.artifacts.readArtifact(fullName);
-        const deploySize = Buffer.from(
+        const deploySize = deployedBytecode? Buffer.from(
           deployedBytecode.replace(/__\$\w*\$__/g, '0'.repeat(40)).slice(2),
           'hex',
-        ).length;
-        const initSize = Buffer.from(
+        ).length: 0;
+        const initSize = bytecode? Buffer.from(
           bytecode.replace(/__\$\w*\$__/g, '0'.repeat(40)).slice(2),
           'hex',
-        ).length;
+        ).length: 0;
 
         outputData.push({
           fullName,


### PR DESCRIPTION
**Fix for "TypeError: Cannot read properties of undefined (reading 'replace')" issue happening when reading some precompiled contracts (ex.: Uniswap V2)**

In some rare cases, when precompiled JSONs are imported directly from npm packages, without recompiling (ex.: Uniswap V2 can't be compiled from sources without modifying them because of the hardcoded init code hashes), the `deployedBytecode` property can be absent, leading to a very frustrating error message:

```
npx hardhat size-contracts

An unexpected error occurred:

TypeError: Cannot read properties of undefined (reading 'replace')
    at .../node_modules/hardhat-contract-sizer/tasks/size_contracts.js:67:24
    at async Promise.all (index 23)
    at SimpleTaskDefinition.action (.../node_modules/hardhat-contract-sizer/tasks/size_contracts.js:60:3)
    at Environment._runTaskDefinition (.../node_modules/hardhat/src/internal/core/runtime-environment.ts:351:14)
    at Environment.run (...node_modules/hardhat/src/internal/core/runtime-environment.ts:184:14)
    at main (.../node_modules/hardhat/src/internal/cli/cli.ts:325:7)
```

This error can be fixed via `config contractSizer.except` array, but guessing the source of the issue is hard.

The proposed fix is to treat precompiled contracts with no `deployedBytecode` or no bytecode as the contracts with zero size `deployedBytecode` or/and `bytecode`. The fix makes the display correct and allows users to either ignore the issue or to handle it by excluding zero-sized contracts:

```
·---------------------------|--------------------------------|--------------------------------·
 |  Solc version: 0.8.20     ·  Optimizer enabled: true       ·  Runs: 200                     │
 ····························|································|·································
 |  Contract Name            ·  Deployed size (KiB) (change)  ·  Initcode size (KiB) (change)  │
 ····························|································|·································
 |  UniswapV2Factory         ·                      0.000 ()  ·                     13.630 ()  │
 ····························|································|·································
 |  UniswapV2Pair            ·                      0.000 ()  ·                     11.362 ()  │
 ····························|································|·································
 |  WETH9                    ·                      0.000 ()  ·                      2.459 ()  │
 ····························|································|·································
 |  UniswapV2Router02        ·                      0.000 ()  ·                     21.810 ()  │
```
